### PR TITLE
Use (os.Stdout, os.Stderr) as default instead of (/dev/stdout, /dev/stderr)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /bin
+access.log
+error.log

--- a/config.example.yml
+++ b/config.example.yml
@@ -4,17 +4,17 @@
 #   127.0.0.1:8080
 #   SERVER_STARTER:0.0.0.0:8080
 #   SERVER_STARTER:/path/to/socket
-listen: "SERVER_STARTER:0.0.0.0:9099"
+listen: "0.0.0.0:9099"
 
 # access_log (optional)
 access_log:
   format: "ltsv"
-  path: "/dev/stdout"
+  path: "./access.log" # optional (default: os.Stdout)
   fields: ["time", "time_nsec", "status", "size", "reqtime_nsec", "backend", "path", "query", "method"]
 
-# error_log (required)
+# error_log (optional)
 error_log:
-  path: "/dev/stderr"
+  path: "./error.log" # default: os.Stderr
 
 # exporters: The path of exporter_proxy and the URL of the destination exporter
 exporters:

--- a/config/config.go
+++ b/config/config.go
@@ -17,12 +17,12 @@ type Config struct {
 	ShutDownTimeout *time.Duration            `yaml:"shutdown_timeout"`
 	ExporterConfigs map[string]ExporterConfig `yaml:"exporters" validate:"required,dive"`
 	AccessLogConfig *AccessLogConfig          `yaml:"access_log"`
-	ErrorLogConfig  *ErrorLogConfig           `yaml:"error_log" validate:"required,dive"`
+	ErrorLogConfig  *ErrorLogConfig           `yaml:"error_log"`
 }
 
 type AccessLogConfig struct {
 	Format *string  `yaml:"format" validate:"required"`
-	Path   *string  `yaml:"path" validate:"required"`
+	Path   *string  `yaml:"path"`
 	Fields []string `yaml:"fields" validate:"required"`
 }
 


### PR DESCRIPTION
Because /dev/stdout and /dev/stderr are not standard file.
For example, running under systemd environment and specify StandardOutput=journal, /dev/stdout will be unix socket.